### PR TITLE
Add Record Routes Implementation

### DIFF
--- a/prisma/migrations/20250321033022_add_symptoms_to_record/migration.sql
+++ b/prisma/migrations/20250321033022_add_symptoms_to_record/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Record" ADD COLUMN     "symptoms" TEXT[];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,6 +64,7 @@ model Record {
   authorRole String
   content    String
   createdAt  DateTime     @default(now())
+  symptoms   String[]
   reads      RecordRead[]
 }
 

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -3,4 +3,5 @@ export enum Errors {
   READ_RECORD = 'Error when adding read record to database.',
   GET_UNREAD_RECORDS = 'Error when getting unread records from database.',
   GET_READ_RECORD = 'Error when getting read record from database.',
+  GET_RECORDS = 'Error when getting records from database.',
 }

--- a/src/common/init-routes.ts
+++ b/src/common/init-routes.ts
@@ -1,9 +1,15 @@
 import ReadRecordService from '../read-record/read-record.service';
+import RecordService from '../record/record.service';
 import ReadRecordController from '../read-record/read-record.controller';
+import RecordController from '../record/record.controller';
 import { Router } from 'express';
 import { injector } from '.';
 
 export function initStatusRoutes(router: Router) {
    const controller = new ReadRecordController(router, injector.getService(ReadRecordService));
+   controller.initRoutes();
+}
+export function initRecordRoutes(router: Router) {
+   const controller = new RecordController(router, injector.getService(RecordService));
    controller.initRoutes();
 }

--- a/src/common/roles.ts
+++ b/src/common/roles.ts
@@ -1,0 +1,5 @@
+export enum Roles {
+  Therapist = 'Therapist',
+  Educationist = 'Educationist',
+  Child = 'Child'
+}

--- a/src/read-record/read-record.controller.ts
+++ b/src/read-record/read-record.controller.ts
@@ -48,11 +48,17 @@ class ReadRecordController {
       try {
          const { recordId } = req.params;
          const readRecord = await this.readRecordService.getReadRecord(Number(recordId));
-
-         new SuccessResult({
-            msg: Result.transformRequestOnMsg(req),
-            data: readRecord,
-         }).handle(res);
+         
+         if (!readRecord) {
+            new FailureResult({
+               msg: Errors.GET_READ_RECORD,
+            }).handle(res);
+         } else {
+            new SuccessResult({
+               msg: Result.transformRequestOnMsg(req),
+               data: readRecord,
+            }).handle(res);
+         }
       } catch (e) {
          new FailureResult({
             msg: Errors.GET_READ_RECORD,

--- a/src/record/record.controller.ts
+++ b/src/record/record.controller.ts
@@ -1,3 +1,5 @@
+import { Errors } from "../common/errors";
+import { FailureResult, Result, SuccessResult } from "../common/results";
 import RecordService from "./record.service";
 import { Router, Request, Response } from 'express';
 
@@ -10,6 +12,89 @@ class RecordController {
         this.recordService = recordService;
         this.initRoutes();
     }
+
+    async getByChild(req: Request, res: Response) : Promise<void> {
+        try {
+            const childId = Number(req.params.childId);
+            const { filter, limit, page } = req.query;
+            const records = await this.recordService.getRecordsByChild(
+                childId,
+                filter as string,
+                Number(limit),
+                Number(page));
+            new SuccessResult({
+                msg: Result.transformRequestOnMsg(req),
+                data: records
+            }).handle(res);
+        } catch (error) {
+            new FailureResult({
+                msg: Errors.GET_RECORDS
+            }).handle(res);
+        }
+    }
+
+    async getByChildAndTherapist(req: Request, res: Response): Promise<void>  {
+        try {
+            const { childId, therapistId } = req.params;
+            console.log(childId, therapistId);
+            const records = await this.recordService.getRecordsByChildAndTherapist(Number(childId), Number(therapistId));
+            console.log(records);
+            new SuccessResult({
+                msg: Result.transformRequestOnMsg(req),
+                data: records
+            }).handle(res);
+        } catch (error) {
+            new FailureResult({
+                msg: Errors.GET_RECORDS
+            }).handle(res);
+        }
+    }
+
+    async getByChildAndEducationist(req: Request, res: Response) : Promise<void> {
+        try {
+            const { childId, educationistId } = req.params;
+            const records = await this.recordService.getRecordsByChildAndEducationist(Number(childId), Number(educationistId));
+            new SuccessResult({
+                msg: Result.transformRequestOnMsg(req),
+                data: records
+            }).handle(res);
+        } catch (error) {
+            new FailureResult({
+                msg: Errors.GET_RECORDS
+            }).handle(res);
+        }
+    }
+
+    async getByTherapist(req: Request, res: Response) : Promise<void> {
+        try {
+            const therapistId = Number(req.params.therapistId);
+            const status = req.query.status as string;
+            const records = await this.recordService.getRecordsByTherapist(therapistId, status);
+            new SuccessResult({
+                msg: Result.transformRequestOnMsg(req),
+                data: records
+            }).handle(res);
+        } catch (error) {
+            new FailureResult({
+                msg: Errors.GET_RECORDS
+            }).handle(res);
+        }
+    }
+
+    async getByEducationist(req: Request, res: Response) : Promise<void> {
+        try {
+            const educationistId = Number(req.params.educationistId);
+            const status = req.query.status as string;
+            const records = await this.recordService.getRecordsByEducationist(educationistId, status);
+            new SuccessResult({
+                msg: Result.transformRequestOnMsg(req),
+                data: records
+            }).handle(res);
+        } catch (error) {
+            new FailureResult({
+                msg: Errors.GET_RECORDS
+            }).handle(res);
+        }
     }
 
     public initRoutes() {

--- a/src/record/record.controller.ts
+++ b/src/record/record.controller.ts
@@ -2,25 +2,22 @@ import RecordService from "./record.service";
 import { Router, Request, Response } from 'express';
 
 class RecordController {
-    public router;
-    private prefix: string = '/record';
+    public router: Router;
     private recordService: RecordService;
 
     constructor(router: Router, recordService: RecordService) {
         this.router = router;
         this.recordService = recordService;
-
-        this.init();
+        this.initRoutes();
+    }
     }
 
-    private init() {
-        this.router.get(`${this.prefix}/example`, (req: Request, res: Response) => {
-            this.example(req, res);
-          });
-    }
-
-    private example(req: Request, res: Response) {
-        return res.send('Spool!');
+    public initRoutes() {
+        this.router.get('/record/child/:childId', async (req, res) => this.getByChild(req, res));
+        this.router.get('/record/child/:childId/therapist/:therapistId', async (req, res) => this.getByChildAndTherapist(req, res));
+        this.router.get('/record/child/:childId/educationist/:educationistId', async (req, res) => this.getByChildAndEducationist(req, res));
+        this.router.get('/record/educationist/:educationistId', async (req, res) => this.getByEducationist(req, res));
+        this.router.get('/record/therapist/:therapistId', async (req, res) => this.getByTherapist(req, res));
     }
 }
 

--- a/src/record/record.controller.ts
+++ b/src/record/record.controller.ts
@@ -36,9 +36,13 @@ class RecordController {
     async getByChildAndTherapist(req: Request, res: Response): Promise<void>  {
         try {
             const { childId, therapistId } = req.params;
-            console.log(childId, therapistId);
-            const records = await this.recordService.getRecordsByChildAndTherapist(Number(childId), Number(therapistId));
-            console.log(records);
+            const { limit, page } = req.query;
+            const records = await this.recordService.getRecordsByChildAndTherapist(
+                Number(childId),
+                Number(therapistId),
+                Number(limit),
+                Number(page)
+            );
             new SuccessResult({
                 msg: Result.transformRequestOnMsg(req),
                 data: records
@@ -53,7 +57,13 @@ class RecordController {
     async getByChildAndEducationist(req: Request, res: Response) : Promise<void> {
         try {
             const { childId, educationistId } = req.params;
-            const records = await this.recordService.getRecordsByChildAndEducationist(Number(childId), Number(educationistId));
+            const { limit, page } = req.query;
+            const records = await this.recordService.getRecordsByChildAndEducationist(
+                Number(childId),
+                Number(educationistId),
+                Number(limit),
+                Number(page)
+            );
             new SuccessResult({
                 msg: Result.transformRequestOnMsg(req),
                 data: records
@@ -68,8 +78,14 @@ class RecordController {
     async getByTherapist(req: Request, res: Response) : Promise<void> {
         try {
             const therapistId = Number(req.params.therapistId);
+            const { limit, page } = req.query;
             const status = req.query.status === 'true' ? true : req.query.status === 'false' ? false : undefined;
-            const records = await this.recordService.getRecordsByTherapist(therapistId, status);
+            const records = await this.recordService.getRecordsByTherapist(
+                therapistId, 
+                status,
+                Number(limit),
+                Number(page)
+            );
             new SuccessResult({
                 msg: Result.transformRequestOnMsg(req),
                 data: records
@@ -84,8 +100,14 @@ class RecordController {
     async getByEducationist(req: Request, res: Response) : Promise<void> {
         try {
             const educationistId = Number(req.params.educationistId);
+            const { limit, page } = req.query;
             const status = req.query.status === 'true' ? true : req.query.status === 'false' ? false : undefined;
-            const records = await this.recordService.getRecordsByEducationist(educationistId, status);
+            const records = await this.recordService.getRecordsByEducationist(
+                educationistId,
+                status,
+                Number(limit),
+                Number(page),
+            );
             new SuccessResult({
                 msg: Result.transformRequestOnMsg(req),
                 data: records

--- a/src/record/record.controller.ts
+++ b/src/record/record.controller.ts
@@ -19,7 +19,7 @@ class RecordController {
             const { filter, limit, page } = req.query;
             const records = await this.recordService.getRecordsByChild(
                 childId,
-                filter as string,
+                Number(filter),
                 Number(limit),
                 Number(page));
             new SuccessResult({
@@ -68,7 +68,7 @@ class RecordController {
     async getByTherapist(req: Request, res: Response) : Promise<void> {
         try {
             const therapistId = Number(req.params.therapistId);
-            const status = req.query.status as string;
+            const status = req.query.status === 'true' ? true : req.query.status === 'false' ? false : undefined;
             const records = await this.recordService.getRecordsByTherapist(therapistId, status);
             new SuccessResult({
                 msg: Result.transformRequestOnMsg(req),
@@ -84,7 +84,7 @@ class RecordController {
     async getByEducationist(req: Request, res: Response) : Promise<void> {
         try {
             const educationistId = Number(req.params.educationistId);
-            const status = req.query.status as string;
+            const status = req.query.status === 'true' ? true : req.query.status === 'false' ? false : undefined;
             const records = await this.recordService.getRecordsByEducationist(educationistId, status);
             new SuccessResult({
                 msg: Result.transformRequestOnMsg(req),

--- a/src/record/record.repository.ts
+++ b/src/record/record.repository.ts
@@ -1,5 +1,6 @@
 import { PrismaClient } from '@prisma/client';
 import { Errors } from '../common/errors';
+import { Roles } from '../common/roles';
 
 class RecordRepository {
   private prisma: PrismaClient;
@@ -10,7 +11,7 @@ class RecordRepository {
   public async getRecordsByChild(childId: number, limit: number, page: number, role?: string): Promise<any[]> {
     try {
       return await this.prisma.record.findMany({
-        where: { 
+        where: {
           childId,
           ...(role && { authorRole: { equals: role, mode: "insensitive" } }),
         },
@@ -28,8 +29,9 @@ class RecordRepository {
     try {
       return await this.prisma.record.findMany({
         where: {
-          childId,
-          child: { therapists: { some: { therapistId } } },
+          childId: childId,
+          authorId: therapistId,
+          authorRole: Roles.Therapist,
         },
         take: limit,
         skip: (page - 1) * limit,
@@ -45,8 +47,9 @@ class RecordRepository {
     try {
       return await this.prisma.record.findMany({
         where: {
-          childId,
-          child: { educationists: { some: { educationistId } } },
+          childId: childId,
+          authorId: educationistId,
+          authorRole: Roles.Educationist,
         },
         take: limit,
         skip: (page - 1) * limit,
@@ -65,9 +68,10 @@ class RecordRepository {
           child: { therapists: { some: { therapistId } } },
           ...(status === false && {
             reads: { none: { 
-              userId: therapistId, 
-              userRole: { contains: 'Therapist', mode: 'insensitive' }
-            }}
+                userId: therapistId,
+                userRole: {contains: Roles.Therapist, mode: 'insensitive'}
+              }
+            }
           })
         },
         take: limit,
@@ -87,9 +91,10 @@ class RecordRepository {
           child: { educationists: { some: { educationistId } } },
           ...(status === false && {
             reads: { none: { 
-              userId: educationistId, 
-              userRole: { contains: 'Educationist', mode: 'insensitive' }
-            }}
+                userId: educationistId,
+                userRole: {contains: Roles.Educationist, mode: 'insensitive'}
+              }
+            }
           })
         },
         take: limit,

--- a/src/record/record.repository.ts
+++ b/src/record/record.repository.ts
@@ -1,4 +1,93 @@
+import { PrismaClient } from '@prisma/client';
+import { Errors } from '../common/errors';
+
 class RecordRepository {
+  private prisma: PrismaClient;
+
+  constructor() {
+    this.prisma = new PrismaClient();
+  }
+
+  public async getRecordsByChild(childId: number, limit: number, page: number, role?: string): Promise<any[]> {
+    try {
+      return await this.prisma.record.findMany({
+        where: { 
+          childId,
+          ...(role && { authorRole: role }),
+        },
+        take: limit,
+        skip: (page - 1) * limit,
+        orderBy: { createdAt: 'desc' },
+      });
+    } catch (e) {
+      console.error(Errors.GET_RECORDS, e);
+      throw new Error(Errors.GET_RECORDS);
+    }
+  }
+
+  public async getRecordsByChildAndTherapist(childId: number, therapistId: number): Promise<any[]> {
+    try {
+      return await this.prisma.record.findMany({
+        where: {
+          childId,
+          child: { therapists: { some: { therapistId } } },
+        },
+        orderBy: { createdAt: 'desc' },
+      });
+    } catch (e) {
+      console.error(Errors.GET_RECORDS, e);
+      throw new Error(Errors.GET_RECORDS);
+    }
+  }
+
+  public async getRecordsByChildAndEducationist(childId: number, educationistId: number): Promise<any[]> {
+    try {
+      return await this.prisma.record.findMany({
+        where: {
+          childId,
+          child: { educationists: { some: { educationistId } } },
+        },
+        orderBy: { createdAt: 'desc' },
+      });
+    } catch (e) {
+      console.error(Errors.GET_RECORDS, e);
+      throw new Error(Errors.GET_RECORDS);
+    }
+  }
+
+  public async getRecordsByTherapist(therapistId: number, status?: string): Promise<any[]> {
+    try {
+      return await this.prisma.record.findMany({
+        where: {
+          child: { therapists: { some: { therapistId } } },
+          ...(status === 'unread' && {
+            reads: { none: { userId: therapistId, userRole: 'Therapist'} }
+          })
+        },
+        orderBy: { createdAt: 'desc' },
+      });
+    } catch (e) {
+      console.error(Errors.GET_RECORDS, e);
+      throw new Error(Errors.GET_RECORDS);
+    }
+  }
+
+  public async getRecordsByEducationist(educationistId: number, status?: string): Promise<any[]> {
+    try {
+      return await this.prisma.record.findMany({
+        where: {
+          child: { educationists: { some: { educationistId } } },
+          ...(status === 'unread' && {
+            reads: { none: { userId: educationistId, userRole: 'Educationist'} }
+          })
+        },
+        orderBy: { createdAt: 'desc' },
+      });
+    } catch (e) {
+      console.error(Errors.GET_RECORDS, e);
+      throw new Error(Errors.GET_RECORDS);
+    }
+  }
 }
 
 export default RecordRepository;

--- a/src/record/record.repository.ts
+++ b/src/record/record.repository.ts
@@ -24,13 +24,15 @@ class RecordRepository {
     }
   }
 
-  public async getRecordsByChildAndTherapist(childId: number, therapistId: number): Promise<any[]> {
+  public async getRecordsByChildAndTherapist(childId: number, therapistId: number, limit: number, page: number): Promise<any[]> {
     try {
       return await this.prisma.record.findMany({
         where: {
           childId,
           child: { therapists: { some: { therapistId } } },
         },
+        take: limit,
+        skip: (page - 1) * limit,
         orderBy: { createdAt: 'desc' },
       });
     } catch (e) {
@@ -39,13 +41,15 @@ class RecordRepository {
     }
   }
 
-  public async getRecordsByChildAndEducationist(childId: number, educationistId: number): Promise<any[]> {
+  public async getRecordsByChildAndEducationist(childId: number, educationistId: number, limit: number, page: number): Promise<any[]> {
     try {
       return await this.prisma.record.findMany({
         where: {
           childId,
           child: { educationists: { some: { educationistId } } },
         },
+        take: limit,
+        skip: (page - 1) * limit,
         orderBy: { createdAt: 'desc' },
       });
     } catch (e) {
@@ -54,7 +58,7 @@ class RecordRepository {
     }
   }
 
-  public async getRecordsByTherapist(therapistId: number, status?: boolean): Promise<any[]> {
+  public async getRecordsByTherapist(therapistId: number, limit: number, page: number, status?: boolean): Promise<any[]> {
     try {
       return await this.prisma.record.findMany({
         where: {
@@ -66,6 +70,8 @@ class RecordRepository {
             }}
           })
         },
+        take: limit,
+        skip: (page - 1) * limit,
         orderBy: { createdAt: 'desc' },
       });
     } catch (e) {
@@ -74,7 +80,7 @@ class RecordRepository {
     }
   }
 
-  public async getRecordsByEducationist(educationistId: number, status?: boolean): Promise<any[]> {
+  public async getRecordsByEducationist(educationistId: number, limit: number, page: number, status?: boolean, ): Promise<any[]> {
     try {
       return await this.prisma.record.findMany({
         where: {
@@ -86,6 +92,8 @@ class RecordRepository {
             }}
           })
         },
+        take: limit,
+        skip: (page - 1) * limit,
         orderBy: { createdAt: 'desc' },
       });
     } catch (e) {

--- a/src/record/record.repository.ts
+++ b/src/record/record.repository.ts
@@ -3,7 +3,6 @@ import { Errors } from '../common/errors';
 
 class RecordRepository {
   private prisma: PrismaClient;
-
   constructor() {
     this.prisma = new PrismaClient();
   }
@@ -13,7 +12,7 @@ class RecordRepository {
       return await this.prisma.record.findMany({
         where: { 
           childId,
-          ...(role && { authorRole: role }),
+          ...(role && { authorRole: { equals: role, mode: "insensitive" } }),
         },
         take: limit,
         skip: (page - 1) * limit,
@@ -55,13 +54,16 @@ class RecordRepository {
     }
   }
 
-  public async getRecordsByTherapist(therapistId: number, status?: string): Promise<any[]> {
+  public async getRecordsByTherapist(therapistId: number, status?: boolean): Promise<any[]> {
     try {
       return await this.prisma.record.findMany({
         where: {
           child: { therapists: { some: { therapistId } } },
-          ...(status === 'unread' && {
-            reads: { none: { userId: therapistId, userRole: 'Therapist'} }
+          ...(status === false && {
+            reads: { none: { 
+              userId: therapistId, 
+              userRole: { contains: 'Therapist', mode: 'insensitive' }
+            }}
           })
         },
         orderBy: { createdAt: 'desc' },
@@ -72,13 +74,16 @@ class RecordRepository {
     }
   }
 
-  public async getRecordsByEducationist(educationistId: number, status?: string): Promise<any[]> {
+  public async getRecordsByEducationist(educationistId: number, status?: boolean): Promise<any[]> {
     try {
       return await this.prisma.record.findMany({
         where: {
           child: { educationists: { some: { educationistId } } },
-          ...(status === 'unread' && {
-            reads: { none: { userId: educationistId, userRole: 'Educationist'} }
+          ...(status === false && {
+            reads: { none: { 
+              userId: educationistId, 
+              userRole: { contains: 'Educationist', mode: 'insensitive' }
+            }}
           })
         },
         orderBy: { createdAt: 'desc' },

--- a/src/record/record.service.ts
+++ b/src/record/record.service.ts
@@ -2,10 +2,38 @@ import RecordRepository from "./record.repository";
 
 class RecordService {
     private recordRepository: RecordRepository;
-
+    private validRoles = ['Educationist', 'Therapist', 'Parent'];
     constructor(recordRepository: RecordRepository) {
         this.recordRepository = recordRepository;
     }
+
+  async getRecordsByChild(childId: number, authorRole?: string, limit?: number, page?: number) {
+    if (authorRole && !this.validRoles.includes(authorRole)) {
+      throw new Error('Invalid role');
+    }
+
+    page = page || 1;
+    limit = limit || 10;
+
+    return this.recordRepository.getRecordsByChild(childId, limit, page, authorRole);
+  }
+
+  async getRecordsByChildAndTherapist(childId: number, therapistId: number) {
+    return this.recordRepository.getRecordsByChildAndTherapist(childId, therapistId);
+  }
+
+  async getRecordsByChildAndEducationist(childId: number, educationistId: number) {
+    return this.recordRepository.getRecordsByChildAndEducationist(childId, educationistId);
+  }
+
+  async getRecordsByTherapist(therapistId: number, status?: string) {
+
+    return this.recordRepository.getRecordsByTherapist(therapistId, status);
+  }
+
+  async getRecordsByEducationist(educationistId: number, status?: string) {
+    return this.recordRepository.getRecordsByEducationist(educationistId, status);
+  }
 }
 
 export default RecordService;

--- a/src/record/record.service.ts
+++ b/src/record/record.service.ts
@@ -1,39 +1,47 @@
 import RecordRepository from "./record.repository";
 
 class RecordService {
-    private recordRepository: RecordRepository;
-    private validRoles = ['Child','Educationist', 'Therapist'];
-    constructor(recordRepository: RecordRepository) {
-        this.recordRepository = recordRepository;
-    }
+  private recordRepository: RecordRepository;
+  private validRoles = ['Child','Educationist', 'Therapist'];
+  constructor(recordRepository: RecordRepository) {
+      this.recordRepository = recordRepository;
+  }
 
+  private getPagination(page?: number, limit?: number) : any{
+    limit = limit || 10;
+    page = page || 1;
+    return { page, limit };
+  }
+  
   async getRecordsByChild(childId: number, authorRole?: number, limit?: number, page?: number) {
     const role = authorRole !== undefined ? this.validRoles[authorRole] : undefined;
     if (role && !this.validRoles.includes(role)) {
         throw new Error('Invalid role');
     }
 
-    page = page || 1;
-    limit = limit || 10;
+    ({ page, limit } = this.getPagination(page, limit));
 
-    return this.recordRepository.getRecordsByChild(childId, limit, page, role);
+    return this.recordRepository.getRecordsByChild(childId, limit!, page!, role);
   }
 
-  async getRecordsByChildAndTherapist(childId: number, therapistId: number) {
-    return this.recordRepository.getRecordsByChildAndTherapist(childId, therapistId);
+  async getRecordsByChildAndTherapist(childId: number, therapistId: number, limit?: number, page?: number) {
+    ({ page, limit } = this.getPagination(page, limit));
+    return this.recordRepository.getRecordsByChildAndTherapist(childId, therapistId, limit!, page!);
   }
 
-  async getRecordsByChildAndEducationist(childId: number, educationistId: number) {
-    return this.recordRepository.getRecordsByChildAndEducationist(childId, educationistId);
+  async getRecordsByChildAndEducationist(childId: number, educationistId: number, limit?: number, page?: number) {
+    ({ page, limit } = this.getPagination(page, limit));
+    return this.recordRepository.getRecordsByChildAndEducationist(childId, educationistId, limit!, page!);
   }
 
-  async getRecordsByTherapist(therapistId: number, status?: boolean) {
-
-    return this.recordRepository.getRecordsByTherapist(therapistId, status);
+  async getRecordsByTherapist(therapistId: number, status?: boolean, limit?: number, page?: number) {
+    ({ page, limit } = this.getPagination(page, limit));
+    return this.recordRepository.getRecordsByTherapist(therapistId, limit!, page!, status);
   }
 
-  async getRecordsByEducationist(educationistId: number, status?: boolean) {
-    return this.recordRepository.getRecordsByEducationist(educationistId, status);
+  async getRecordsByEducationist(educationistId: number, status?: boolean, limit?: number, page?: number) {
+    ({ page, limit } = this.getPagination(page, limit));
+    return this.recordRepository.getRecordsByEducationist(educationistId, limit!, page!, status);
   }
 }
 

--- a/src/record/record.service.ts
+++ b/src/record/record.service.ts
@@ -1,8 +1,9 @@
 import RecordRepository from "./record.repository";
+import { Roles } from "../common/roles";
 
 class RecordService {
   private recordRepository: RecordRepository;
-  private validRoles = ['Child','Educationist', 'Therapist'];
+  private validRoles = [Roles.Child, Roles.Educationist, Roles.Therapist];
   constructor(recordRepository: RecordRepository) {
       this.recordRepository = recordRepository;
   }

--- a/src/record/record.service.ts
+++ b/src/record/record.service.ts
@@ -2,20 +2,21 @@ import RecordRepository from "./record.repository";
 
 class RecordService {
     private recordRepository: RecordRepository;
-    private validRoles = ['Educationist', 'Therapist', 'Child'];
+    private validRoles = ['Child','Educationist', 'Therapist'];
     constructor(recordRepository: RecordRepository) {
         this.recordRepository = recordRepository;
     }
 
-  async getRecordsByChild(childId: number, authorRole?: string, limit?: number, page?: number) {
-    if (authorRole && !this.validRoles.includes(authorRole)) {
-      throw new Error('Invalid role');
+  async getRecordsByChild(childId: number, authorRole?: number, limit?: number, page?: number) {
+    const role = authorRole !== undefined ? this.validRoles[authorRole] : undefined;
+    if (role && !this.validRoles.includes(role)) {
+        throw new Error('Invalid role');
     }
 
     page = page || 1;
     limit = limit || 10;
 
-    return this.recordRepository.getRecordsByChild(childId, limit, page, authorRole);
+    return this.recordRepository.getRecordsByChild(childId, limit, page, role);
   }
 
   async getRecordsByChildAndTherapist(childId: number, therapistId: number) {
@@ -26,12 +27,12 @@ class RecordService {
     return this.recordRepository.getRecordsByChildAndEducationist(childId, educationistId);
   }
 
-  async getRecordsByTherapist(therapistId: number, status?: string) {
+  async getRecordsByTherapist(therapistId: number, status?: boolean) {
 
     return this.recordRepository.getRecordsByTherapist(therapistId, status);
   }
 
-  async getRecordsByEducationist(educationistId: number, status?: string) {
+  async getRecordsByEducationist(educationistId: number, status?: boolean) {
     return this.recordRepository.getRecordsByEducationist(educationistId, status);
   }
 }

--- a/src/record/record.service.ts
+++ b/src/record/record.service.ts
@@ -2,7 +2,7 @@ import RecordRepository from "./record.repository";
 
 class RecordService {
     private recordRepository: RecordRepository;
-    private validRoles = ['Educationist', 'Therapist', 'Parent'];
+    private validRoles = ['Educationist', 'Therapist', 'Child'];
     constructor(recordRepository: RecordRepository) {
         this.recordRepository = recordRepository;
     }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,15 +1,9 @@
 import { Router } from 'express';
-import { initStatusRoutes } from './common/init-routes';
-
+import { initRecordRoutes, initStatusRoutes } from './common/init-routes';
 const router = Router();
 
 // Routes group for record
-router.get('/record/child/:childId', );
-router.get('/record/child/:childId/therapist/:therapistId', );
-router.get('/record/child/:childId/educationist/:educationistId', );
-router.get('/record/educationist/:educationistId', );
-router.get('/record/therapist/:therapistId', );
-router.post('/record');
+initRecordRoutes(router);
 
 // Routes group for child
 router.get('/child/:childId/educationist');


### PR DESCRIPTION
### Description
Implemented new routes for fetching records based on different filters

#### **Changes Made:**
  - **GET `/record/child/:childId`**: Fetch records for a specific child. Allows filtering by the record author role using `filter` (0 - Child, 1 - Educationist, 2 - Therapist).
  - **GET `/record/child/:childId/therapist/:therapistId`**: Fetch all records for a specific child that were written by a specific therapist.
  - **GET `/record/child/:childId/educationist/:educationistId`**: Fetch all records for a specific child that were written by a specific educationist.
  - **GET `/record/educationist/:educationistId`**: Fetch all records associated with all children that the educationist has access to. Supports filtering by **status** (false for unread records).
  - **GET `/record/therapist/:therapistId`**: Fetch all records associated with all children that the therapist has access to. Supports filtering by **status** (false for unread records).

All routes support pagination with `limit` and `page`