### PR TITLE
Bug Fixes in Alert Route​

### DIFF
--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -14,4 +14,5 @@ export enum Errors {
   SAVE_DEVICE_TOKEN = 'Error when saving device token in database.',
   GET_USER_INFO = 'Error when getting user info from database.',
   SEND_NOTIFICATION = 'Error when sending notification.',
+  INVALID_ROLE = 'Invalid role! Valid roles are Child, Therapist, and Educationist.',
 }

--- a/src/read-record/read-record.controller.ts
+++ b/src/read-record/read-record.controller.ts
@@ -1,4 +1,3 @@
-import { ParsedQs } from "qs";
 import { FailureResult, Result, SuccessResult } from "../common/results";
 import ReadRecordService from "./read-record.service";
 import { Request, Response, Router } from "express";
@@ -12,22 +11,6 @@ class ReadRecordController {
       this.router = router;
       this.readRecordService = readRecordService;
       this.initRoutes();
-   }
-
-   public async getUnreadRecords(req: Request, res: Response): Promise<void> {
-      try {
-         const { userId } = req.params;
-         const unreadRecords = await this.readRecordService.getUnreadRecords(Number(userId));
-
-         new SuccessResult({
-            msg: Result.transformRequestOnMsg(req),
-            data: unreadRecords,
-         }).handle(res);
-      } catch (e) {
-         new FailureResult({
-            msg: Errors.GET_UNREAD_RECORDS,
-         }).handle(res);
-      }
    }
 
    public async readRecord(req: Request, res: Response): Promise<void> {
@@ -67,7 +50,6 @@ class ReadRecordController {
    }
 
    public initRoutes() {
-      this.router.get('/alerts/:userId', (req, res) => this.getUnreadRecords(req, res));
       this.router.get('/read/:recordId', (req, res) => this.getReadRecord(req, res));
       this.router.post('/read', (req, res) => this.readRecord(req, res) ); 
    }

--- a/src/read-record/read-record.repository.ts
+++ b/src/read-record/read-record.repository.ts
@@ -29,35 +29,9 @@ class ReadRecordRepository {
     }
   }
 
-  public async getUnreadRecordsFromDatabase(userId: number): Promise<any[]> {
-   try {
-      const readRecordIds = await this.prisma.recordRead.findMany({
-         where: {
-           userId: userId
-         },
-         select: {
-           recordId: true,
-         },
-      }).then(records => records.map(record => record.recordId));
-   
-      const unreadRecords = await this.prisma.record.findMany({
-         where: {
-            id: {
-               in: readRecordIds,
-            },
-         },
-      });
-
-      return unreadRecords;
-   } catch (e) {
-      console.error(Errors.GET_UNREAD_RECORDS, e);
-      throw new Error(Errors.GET_UNREAD_RECORDS);
-   }
- }
-
    public async getReadRecord(recordId: number): Promise<any> {
       try {
-         return await this.prisma.recordRead.findFirst({
+         return await this.prisma.recordRead.findMany({
             where: {
                recordId,
             },

--- a/src/read-record/read-record.service.ts
+++ b/src/read-record/read-record.service.ts
@@ -11,10 +11,6 @@ class ReadRecordService {
       return this.readRecordRepository.readRecord(recordId, userId, userRole);
    }
 
-   getUnreadRecords(userId: number) {
-      return this.readRecordRepository.getUnreadRecordsFromDatabase(userId);
-   }
-
    getReadRecord(recordId: number) {
       return this.readRecordRepository.getReadRecord(recordId);
    }

--- a/src/record/record.controller.ts
+++ b/src/record/record.controller.ts
@@ -151,6 +151,29 @@ class RecordController {
         }
     }
 
+    public async getUnreadRecords(req: Request, res: Response): Promise<void> {
+        try {
+            const { userId } = req.params;
+            var { role, page, limit } = req.query;
+            
+            const unreadRecords = await this.recordService.getUnreadRecords(
+                Number(userId),
+                String(role),
+                Number(limit),
+                Number(page)
+            );
+            
+            new SuccessResult({
+                msg: Result.transformRequestOnMsg(req),
+                data: unreadRecords,
+            }).handle(res);
+        } catch (e) {
+            new FailureResult({
+                msg: Errors.GET_UNREAD_RECORDS,
+            }).handle(res);
+        }
+    }
+
     public initRoutes() {
         this.router.get('/record/child/:childId', async (req, res) => this.getByChild(req, res));
         this.router.get('/record/child/:childId/therapist/:therapistId', async (req, res) => this.getByChildAndTherapist(req, res));
@@ -158,6 +181,7 @@ class RecordController {
         this.router.get('/record/educationist/:educationistId', async (req, res) => this.getByEducationist(req, res));
         this.router.get('/record/therapist/:therapistId', async (req, res) => this.getByTherapist(req, res));
         this.router.post('/record', async (req, res) => this.createRecord(req, res));
+        this.router.get('/alerts/:userId', (req, res) => this.getUnreadRecords(req, res));
     }
 }
 

--- a/src/record/record.repository.ts
+++ b/src/record/record.repository.ts
@@ -8,12 +8,19 @@ class RecordRepository {
     this.prisma = new PrismaClient();
   }
 
-  public async getRecordsByChild(childId: number, limit: number, page: number, role?: string): Promise<any[]> {
+  public async getRecordsByChild(childId: number, limit: number, page: number, role?: string, status?: boolean): Promise<any[]> {
     try {
       return await this.prisma.record.findMany({
         where: {
           childId,
           ...(role && { authorRole: { equals: role, mode: "insensitive" } }),
+          ...(status === false && {
+            reads: { none: { 
+                userId: childId,
+                userRole: {contains: Roles.Child, mode: 'insensitive'}
+              }
+            }
+          })
         },
         take: limit,
         skip: (page - 1) * limit,
@@ -84,7 +91,7 @@ class RecordRepository {
     }
   }
 
-  public async getRecordsByEducationist(educationistId: number, limit: number, page: number, status?: boolean, ): Promise<any[]> {
+  public async getRecordsByEducationist(educationistId: number, limit: number, page: number, status?: boolean): Promise<any[]> {
     try {
       return await this.prisma.record.findMany({
         where: {

--- a/src/record/record.service.ts
+++ b/src/record/record.service.ts
@@ -1,5 +1,6 @@
 import RecordRepository from "./record.repository";
 import { Roles } from "../common/roles";
+import { Errors } from "../common/errors";
 
 class RecordService {
   private recordRepository: RecordRepository;
@@ -50,6 +51,25 @@ class RecordService {
       throw new Error('Invalid role');
     }
     return this.recordRepository.createRecord(childId, authorId, authorRole, authorName, content, symptoms);
+  }
+
+  async getUnreadRecords(
+    userId: number, 
+    authorRole: string,
+    limit: number,
+    page: number
+  ): Promise<any> {
+    ({ page, limit } = this.getPagination(page, limit));
+    switch (authorRole) {
+       case Roles.Educationist:
+          return await this.recordRepository.getRecordsByEducationist(userId, limit, page, false);
+       case Roles.Child:
+          return await this.recordRepository.getRecordsByChild(userId, limit, page, undefined, false);
+       case Roles.Therapist:
+          return await this.recordRepository.getRecordsByTherapist(userId, limit, page, false);
+       default:
+          throw new Error(Errors.INVALID_ROLE);
+   }
   }
 }
 


### PR DESCRIPTION
# Summary

This pull request addresses issues identified in the alert route, including:​

- [x] It was returning all read records, not unread records. 
- [x] It was not filtering the read records by the userId and userRole.
- [x] It was not supporting page and limit queries.
- [x] GetByChild was not filtering by status.

To solve these problems, the Alerts route has been integrated into the `RecordController`. The following functions from the `RecordService` are utilized with the status parameter set to `False`, indicating that only unread records should be returned:​ `GetByChild`, `GetByTherapist`, and `GetByEducationist`.

